### PR TITLE
Fixed a few attributes not being picked up in style node

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -143,6 +143,16 @@
   <rect id="test-frame" x="1" y="1" width="478" height="358" fill="none" stroke="#000000"/>
 </svg>
 
+<!-- sound icon with style -->
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <path
+     d="M 69.989182,30.235267 c 5.226048,6.724068 10.451958,13.44796 10.45183,20.172184 -1.28e-4,6.724224 -5.22583,13.447844 -10.45183,20.171848 m 0,-66.373622 c 12.902729,15.400775 25.805268,30.801324 25.805137,46.066004 -1.3e-4,15.26468 -12.902608,30.393632 -25.805137,45.522644"
+     style="display:inline;fill:none;stroke:#000000;stroke-width:7.97791;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1" />
+  <path
+     d="M 55.88845,10.348116 V 91.036199 L 30.078507,65.821173 H 2.5079233 V 35.563151 H 30.078507 Z"
+     style="fill:none;stroke:#000000;stroke-width:5.01584;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;" />
+</svg>
+
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
 <path d="M50,3l12,36h38l-30,22l11,36l-31-21l-31,21l11-36l-30-22h38z" fill="#FF0" stroke="#FC0" stroke-width="2"/>
 </svg>

--- a/src/SVG.js
+++ b/src/SVG.js
@@ -235,7 +235,7 @@ class SVG extends Graphics
 
                     if (!result[convertedName])
                     {
-                        result[this._convertStyleName(name)] = value.trim();
+                        result[convertedName] = value.trim();
                     }
                 }
             });

--- a/src/SVG.js
+++ b/src/SVG.js
@@ -192,6 +192,7 @@ class SVG extends Graphics
 
     /**
      * Convert the SVG style name into usable name.
+     * @private
      * @param {string} name
      * @return {string} name used to reference style
      */

--- a/src/SVG.js
+++ b/src/SVG.js
@@ -195,7 +195,8 @@ class SVG extends Graphics
      * @param {string} name
      * @return {string} name used to reference style
      */
-    _convertStyleName(name) {
+    _convertStyleName(name)
+    {
         return name
             .replace('-width', 'Width')
             .replace(/.*-(line)?/, '');

--- a/src/SVG.js
+++ b/src/SVG.js
@@ -191,6 +191,17 @@ class SVG extends Graphics
     }
 
     /**
+     * Convert the SVG style name into usable name.
+     * @param {string} name
+     * @return {string} name used to reference style
+     */
+    _convertStyleName(name) {
+        return name
+            .replace('-width', 'Width')
+            .replace(/.*-(line)?/, '');
+    }
+
+    /**
      * Get the style property and parse options.
      * @private
      * @method
@@ -218,14 +229,14 @@ class SVG extends Graphics
 
                 if (name)
                 {
-                    result[name.trim()] = value.trim();
+                    const convertedName = this._convertStyleName(name);
+
+                    if (!result[convertedName])
+                    {
+                        result[this._convertStyleName(name)] = value.trim();
+                    }
                 }
             });
-            if (result['stroke-width'])
-            {
-                result.strokeWidth = result['stroke-width'];
-                delete result['stroke-width'];
-            }
         }
 
         return result;

--- a/src/SVG.js
+++ b/src/SVG.js
@@ -199,6 +199,7 @@ class SVG extends Graphics
     _convertStyleName(name)
     {
         return name
+            .trim()
             .replace('-width', 'Width')
             .replace(/.*-(line)?/, '');
     }


### PR DESCRIPTION
This change will allow all style attributes that are already implemented to be referenced inside the style node.Before this change, a few of them only work when referenced directly as an attribute for example stroke-linecap.